### PR TITLE
Change default branch to stackhpc/yoga

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ set -eu
 
 # These parameters must be changed to your own fork 
 KAYOBE_CONFIG_REPO="https://github.com/example/stackhpc-kayobe-config"
-KAYOBE_CONFIG_BRANCH=main
+KAYOBE_CONFIG_BRANCH=stackhpc/yoga
 
 ##########################################################################
 


### PR DESCRIPTION
Changes the default templated branch name from main to stackhpc/yoga as most people who fork the branch will have it named stackhpc/yoga instead of main.

@Alex-Welsh what do you think? (Makes it easier for people instead of having to change the repo and the link. Just a nitpick tbh)