### PR TITLE
Yoga: Revert "Update for 2023.1"

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,13 +7,13 @@ set -eu
 
 # These parameters must be changed to your own fork 
 KAYOBE_CONFIG_REPO="https://github.com/example/stackhpc-kayobe-config"
-KAYOBE_CONFIG_BRANCH=stackhpc/2023.1
+KAYOBE_CONFIG_BRANCH=stackhpc/yoga
 
 ##########################################################################
 
 # These parameters may be changed if you wish to deviate from the defaults
 BASE_PATH=~
-KAYOBE_BRANCH=stackhpc/2023.1
+KAYOBE_BRANCH=stackhpc/yoga 
 KAYOBE_ENVIRONMENT=training
 
 

--- a/kolla.yml
+++ b/kolla.yml
@@ -12,3 +12,4 @@ kolla_overcloud_inventory_custom_services: "{{ lookup('template', kayobe_env_con
 kolla_enable_central_logging: false
 kolla_enable_prometheus: false
 kolla_enable_grafana: false
+kolla_enable_elasticsearch_curator: false

--- a/kolla/config/bifrost/bifrost.yml
+++ b/kolla/config/bifrost/bifrost.yml
@@ -5,4 +5,4 @@ download_ipa: true
 
 # Use a locally hosted CentOS8 cloud image.
 use_cirros: true
-cirros_deploy_image_upstream_url: "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2"
+cirros_deploy_image_upstream_url: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2"

--- a/kolla/globals.yml
+++ b/kolla/globals.yml
@@ -9,5 +9,5 @@ nova_compute_virt_type: qemu
 openstack_service_workers: "1"
 openstack_service_rpc_workers: "1"
 
-# Opensearch memory tuning
-opensearch_heap_size: 1g
+# Elasticsearch memory tuning
+es_heap_size: 1g

--- a/kolla/inventory/overcloud-services.j2
+++ b/kolla/inventory/overcloud-services.j2
@@ -24,12 +24,9 @@ common
 [kolla-toolbox:children]
 common
 
-[opensearch:children]
-control
-
-# Opensearch dashboards
-[opensearch-dashboards:children]
-opensearch
+# Elasticsearch Curator
+[elasticsearch-curator:children]
+elasticsearch
 
 # Glance
 [glance-api:children]
@@ -112,10 +109,6 @@ neutron
 
 [ironic-neutron-agent:children]
 neutron
-
-[neutron-ovn-agent:children]
-compute
-network
 
 # Cinder
 [cinder-api:children]
@@ -450,12 +443,13 @@ compute
 [zun-cni-daemon:children]
 compute
 
-# Skyline
-[skyline-apiserver:children]
-skyline
+# Skydive
+[skydive-analyzer:children]
+skydive
 
-[skyline-console:children]
-skyline
+[skydive-agent:children]
+compute
+network
 
 # Tacker
 [tacker-server:children]
@@ -514,11 +508,14 @@ storage
 [prometheus-alertmanager:children]
 monitoring
 
+[prometheus-msteams:children]
+monitoring
+
 [prometheus-openstack-exporter:children]
 monitoring
 
 [prometheus-elasticsearch-exporter:children]
-opensearch
+elasticsearch
 
 [prometheus-blackbox-exporter:children]
 monitoring
@@ -562,9 +559,3 @@ ovn-database
 
 [ovn-sb-db:children]
 ovn-database
-
-[venus-api:children]
-venus
-
-[venus-manager:children]
-venus

--- a/stackhpc.yml
+++ b/stackhpc.yml
@@ -8,8 +8,5 @@ kolla_docker_namespace: stackhpc-dev
 ###############################################################################
 # StackHPC configuration.
 
-# Base URL of the StackHPC Test Pulp service.
-stackhpc_release_pulp_url: "http://pulp-server.internal.sms-cloud:8080"
-
 pulp_username: admin
 pulp_password: 9e4bfa04-9d9d-493d-9473-ba92e4361dae

--- a/stackhpc.yml
+++ b/stackhpc.yml
@@ -8,5 +8,8 @@ kolla_docker_namespace: stackhpc-dev
 ###############################################################################
 # StackHPC configuration.
 
+# Base URL of the StackHPC Test Pulp service.
+stackhpc_release_pulp_url: "http://pulp-server.internal.sms-cloud:8080"
+
 pulp_username: admin
 pulp_password: 9e4bfa04-9d9d-493d-9473-ba92e4361dae


### PR DESCRIPTION
Accidentally merged Antelope changes into yoga branch.

Keeping the `stackhpc_release_pulp_url` since that is valid for yoga.